### PR TITLE
Add Travis and Appveyor configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+cache: cargo
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+os:
+  - linux
+  - osx
+
+before_script:
+  - env
+
+script:
+  - cargo build --all
+  - cargo test --all
+
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+# Based on the "trust" template v0.1.1
+# https://github.com/japaric/trust/tree/v0.1.1
+
+environment:
+  global:
+  # This is the Rust channel that build jobs will use by default but can be
+  # overridden on a case by case basis down below
+    RUST_VERSION: stable
+
+  # These are all the build jobs. Adjust as necessary. Comment out what you
+  # don't need
+  matrix:
+    # MinGW
+    - TARGET: i686-pc-windows-gnu
+    - TARGET: x86_64-pc-windows-gnu
+
+    # MSVC
+    - TARGET: i686-pc-windows-msvc
+    - TARGET: x86_64-pc-windows-msvc
+
+    # Testing other channels
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: beta
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: beta
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
+
+install:
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  # TMP fix for https://github.com/rust-lang-nursery/rustup.rs/issues/893:
+  - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\%RUST_VERSION%-%TARGET%\bin
+  - rustc -Vv
+  - cargo -V
+
+# This is the "test phase", tweak it as you see fit
+test_script:
+  - cargo build --all --target %TARGET%
+  - cargo test --all --target %TARGET%
+
+# Cache build binaries for faster builds next time
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+# Stops feature branches from triggering two builds (One for branch and one for PR)
+skip_branch_with_pr: true
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+# We build in the test stage, so disable Appveyor's build stage. This prevents
+# the "directory does not contain a project or solution file" error.
+build: false


### PR DESCRIPTION
Adding Erik and Andrei since they have been reviewing this crate before and adding Simon since I know he is interested in the RPC stuff in general.

This crate does not have many tests yet. But the CI serves the purpose to make sure it will at least compile on all platforms. Something that might be easy to miss when the developer is only using one of them. The plan is to add integration/system tests later that actually sets up a server and does some real communication to test everything all the way through.

CI configs mostly copied from our newclient repo, but a bit simpler. No hard requirements on format or anything. (Sidenote: I format this repo with the latest `rustfmt-nightly` which I think is much nicer than `rustfmt 0.8.3`, I think we should switch newclient over at some point.)

If you are worried this will make our already busy build queue even more intolerable I can just say that I think it will be fine. First of all, this crate is pretty small, should be way faster to build than newclient. Also, since this will not see very heavy development once released, there will not be many CI build jobs for this crate in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/9)
<!-- Reviewable:end -->
