### PR TITLE
Make http depend on released core

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -13,5 +13,5 @@ error-chain = "0.10"
 futures = "0.1"
 hyper = "0.11"
 hyper-tls = "0.1"
-jsonrpc-client-core = { path = "../core" }
+jsonrpc-client-core = "0.1"
 tokio-core = "0.1"


### PR DESCRIPTION
In order to publish a crate it must depend only on other published crates. So I had to make this difference to be able to upload the http crate to crates.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/11)
<!-- Reviewable:end -->
