### PR TITLE
Hide expand_params macro from documentation

### DIFF
--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -44,8 +44,9 @@ macro_rules! jsonrpc_client {
 }
 
 /// Expands a variable list of parameters into its serializable form. Is needed to make the params
-/// of a nullary method `[]` instead of `()` and thus make sure it serializes to `[]` instead of
-/// `null`.
+/// of a nullary method equal to `[]` instead of `()` and thus make sure it serializes to `[]`
+/// instead of `null`.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! expand_params {
     () => ([] as [(); 0]);


### PR DESCRIPTION
I have now released version `0.2.0` of these two crates. But upon reading the docs I realized that it's not very nice that the docs show the `expand_params` macro. It is never supposed to be used by anyone using this crate. But it must be exported, otherwise we can't call it from our public macro `jsonrpc_client`.

Then one can hide public stuff from the docs in this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/18)
<!-- Reviewable:end -->
