### PR TITLE
Removing dev-dependency on http in core

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,3 @@ jsonrpc-core = "7.0"
 log = "0.3"
 serde = "1.0"
 serde_json = "1.0"
-
-[dev-dependencies]
-jsonrpc-client-http = "0.2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! # Example
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! #[macro_use] extern crate jsonrpc_client_core;
 //! extern crate jsonrpc_client_http;
 //!


### PR DESCRIPTION
Having circular dependencies like this really created kind of troubles when releasing and uploading to crates.io. Since crates.io only accept dependencies to released crates I needed to point core to 0.2 of the http crate and vice versa. So none of them could be uploaded first since the other was missing. I circumvented that and uploaded anyway, but now I want to remove this circular stuff completely.

We can still have the example code using the http crate, I just tag it with `ignore` so rustdoc does not try to compile or run it. So that puts a bit more responsibility on us it the future to make sure the docs are correct, but at least we don't have a circular dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/19)
<!-- Reviewable:end -->
