### PR TITLE
Update error-chain to 0.11

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mullvad/jsonrpc-client"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-error-chain = "0.10"
+error-chain = "0.11"
 futures = "0.1"
 jsonrpc-core = "7.0"
 log = "0.3"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mullvad/jsonrpc-client"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-error-chain = "0.10"
+error-chain = "0.11"
 futures = "0.1.15"
 hyper = "0.11"
 hyper-tls = { version = "0.1", optional = true }


### PR DESCRIPTION
Lots of small changes. Most notably the motherload of errors it spewed up on nightly are gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/21)
<!-- Reviewable:end -->
