### PR TITLE
Use existing error deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add badges to Cargo.toml.
+
 ### Changed
-- Make internal macro `expand_params` hidden from documentation.
+- Hide internal macro `expand_params` from documentation.
+- Upgrade `error-chain` to 0.11 to get rid of warnings on nightly.
+- Use deserialization support on `jsonrpc-core::Error` instead of implementing it manually.
+
+### Fixed
+- Fix repository url in Cargo.toml.
+
+### Security
+- Upgrade `jsonrpc-core` to 7.1.1 to avoid possible `ErrorKind` deserialization panic.
+
 
 ## [0.2.0] - 2017-08-31
 ### Changed
 - Make transport implementations responsible for IDs for requests.
 - Change core Transport trait to return futures and have the error as associated type.
 - Rewrite basically everything into an async fashion with futures.
+
 
 ## [0.1.0] - 2017-07-19
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 error-chain = "0.11"
 futures = "0.1"
-jsonrpc-core = "7.0"
+jsonrpc-core = "7.1.1"
 log = "0.3"
 serde = "1.0"
 serde_json = "1.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -91,7 +91,7 @@ error_chain! {
             display("Unable to deserialize the response: {}", msg)
         }
         /// The request was replied to, but with a JSON-RPC 2.0 error.
-        JsonRpcError(error: jsonrpc_core::types::error::Error) {
+        JsonRpcError(error: jsonrpc_core::Error) {
             description("Method call returned JSON-RPC 2.0 error")
             display("JSON-RPC 2.0 Error: {} ({})", error.code.description(), error.message)
         }
@@ -277,7 +277,7 @@ mod tests {
         let mut client = TestRpcClient::new(ErrorTransport);
         let error = client.ping("").call().unwrap_err();
         if let &ErrorKind::JsonRpcError(ref json_error) = error.kind() {
-            use jsonrpc_core::types::error::ErrorCode;
+            use jsonrpc_core::ErrorCode;
             assert_eq!(ErrorCode::InvalidRequest, json_error.code);
             assert_eq!("This was an invalid request", json_error.message);
             assert_eq!(Some(json!{[1, 2, 3]}), json_error.data);

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use {Error, ErrorKind, Result, ResultExt};
+use jsonrpc_core;
 use serde;
 use serde_json::{self, Value as JsonValue};
 
@@ -42,7 +43,7 @@ fn check_response_and_get_result(mut response: JsonValue, expected_id: u64) -> R
         ErrorKind::ResponseError("Response id not equal to request id")
     );
     if let Some(error_json) = response_map.remove("error") {
-        let error = serde_json::from_value(error_json)
+        let error: jsonrpc_core::Error = serde_json::from_value(error_json)
             .chain_err(|| ErrorKind::ResponseError("Malformed error object"))?;
         bail!(ErrorKind::JsonRpcError(error));
     }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -15,9 +15,10 @@ futures = "0.1.15"
 hyper = "0.11"
 hyper-tls = { version = "0.1", optional = true }
 native-tls = { version = "0.1", optional = true }
-jsonrpc-client-core = "0.2"
 log = "0.3"
 tokio-core = "0.1"
+
+jsonrpc-client-core = { path = "../core" }
 
 [features]
 default = ["tls"]


### PR DESCRIPTION
I realized it was madness to manually implement going from a `serde_json::Value` to a `jsonrpc_core::Error`. That can of course be done automatically since both are fully serializable.

Also upgraded to newer `jsonrpc-core` when at it.

The dep change in `http` is because when doing local development it's bothersome to point to the release version. Then changes you do locally won't get used. Better to always point to the local versions in the code and then just manually change in the working directory to some fixed release when doing `cargo publish`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/23)
<!-- Reviewable:end -->
