### PR TITLE
Update change log to show 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add integration test in http crate. Testing actual network traffic.
+
+
+## [0.2.1] - 2017-09-11
+### Added
 - Add badges to Cargo.toml.
 
 ### Changed


### PR DESCRIPTION
It's hard to remember the change log! Good to update now especially since there has been a release since it was last updated.

I know it's at least as hard to remember the change log as a reviewer as it is for the one writing the feature/PR. So I'm of course not blaming anyone. But would be nice if we could get it into the process to remember to update the change log in every feature branch, and in reviews point it out and not accept changes that are not described in the log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/25)
<!-- Reviewable:end -->
