### PR TITLE
Simplify response check

### DIFF
--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -25,7 +25,6 @@ default = ["tls"]
 tls = ["hyper-tls", "native-tls"]
 
 [dev-dependencies]
-env_logger = "0.5"
 jsonrpc-core = "8.0"
 jsonrpc-macros = "8.0"
 jsonrpc-http-server = "8.0"

--- a/http/tests/localhost.rs
+++ b/http/tests/localhost.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate env_logger;
 extern crate futures;
 #[macro_use]
 extern crate jsonrpc_client_core;
@@ -48,8 +47,6 @@ jsonrpc_client!(pub struct TestClient {
 
 #[test]
 fn localhost_ping_pong() {
-    let _ = env_logger::init();
-
     // Spawn a server hosting the `ServerApi` API.
     let (_server, uri) = spawn_server();
     println!("Testing towards server at {}", uri);
@@ -79,8 +76,6 @@ fn localhost_ping_pong() {
 
 #[test]
 fn dropped_rpc_request_should_not_crash_transport() {
-    let _ = env_logger::init();
-
     let (_server, uri) = spawn_server();
 
     let mut core = Core::new().unwrap();


### PR DESCRIPTION
Had to remove `env_logger` from the tests. Since the new `env_logger 0.5` now panic in `init()` instead of returning an error I can't run it in multiple tests since the last one to run will panic. No big deal.

Also, removing `check_response` and adding the little code it contained to where it was used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/29)
<!-- Reviewable:end -->
