### PR TITLE
Add support for custom HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow setting custom HTTP headers for RPC requests.
 
 
 ## [0.3.0] - 2018-03-06

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -28,6 +28,7 @@ tls = ["hyper-tls", "native-tls"]
 jsonrpc-core = "8.0"
 jsonrpc-macros = "8.0"
 jsonrpc-http-server = "8.0"
+tokio-service = "0.1"
 
 
 [badges]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -337,13 +337,13 @@ impl HttpHandle {
     /// Creates a Hyper POST request with JSON content type and the given body data.
     fn create_request(&self, body: Vec<u8>) -> Request {
         let mut request = hyper::Request::new(hyper::Method::Post, self.uri.clone());
-        request.headers_mut().extend(self.headers.iter());
         request
             .headers_mut()
             .set(hyper::header::ContentType::json());
         request
             .headers_mut()
             .set(hyper::header::ContentLength(body.len() as u64));
+        request.headers_mut().extend(self.headers.iter());
         request.set_body(body);
         request
     }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -337,13 +337,12 @@ impl HttpHandle {
     /// Creates a Hyper POST request with JSON content type and the given body data.
     fn create_request(&self, body: Vec<u8>) -> Request {
         let mut request = hyper::Request::new(hyper::Method::Post, self.uri.clone());
-        request
-            .headers_mut()
-            .set(hyper::header::ContentType::json());
-        request
-            .headers_mut()
-            .set(hyper::header::ContentLength(body.len() as u64));
-        request.headers_mut().extend(self.headers.iter());
+        {
+            let headers = request.headers_mut();
+            headers.set(hyper::header::ContentType::json());
+            headers.set(hyper::header::ContentLength(body.len() as u64));
+            headers.extend(self.headers.iter());
+        }
         request.set_body(body);
         request
     }

--- a/http/tests/custom_headers.rs
+++ b/http/tests/custom_headers.rs
@@ -1,0 +1,170 @@
+extern crate futures;
+extern crate hyper;
+extern crate jsonrpc_client_core;
+extern crate jsonrpc_client_http;
+extern crate tokio_core;
+extern crate tokio_service;
+
+use std::fmt::Display;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use futures::future::{Future, FutureResult, IntoFuture};
+use futures::sync::oneshot;
+use hyper::{Headers, Request, Response, StatusCode};
+use hyper::header::{ContentLength, ContentType, Header, Host};
+use hyper::server::Http;
+use tokio_core::reactor::Core;
+use tokio_service::Service;
+
+use jsonrpc_client_core::Transport;
+use jsonrpc_client_http::{HttpHandle, HttpTransport};
+
+#[test]
+fn set_host_header() {
+    let hostname = "dummy.url";
+    let port = Some(8081);
+
+    let set = move |transport: &mut HttpHandle| {
+        transport.set_header(Host::new(hostname, port));
+    };
+
+    let check = move |headers: &Headers| {
+        if let Some(host) = headers.get::<Host>() {
+            assert_eq!(host.hostname(), hostname);
+            assert_eq!(host.port(), port);
+        }
+    };
+
+    test_custom_headers(set, check);
+}
+
+#[test]
+fn set_host_header_twice() {
+    let hostname = "dummy.url";
+    let port = Some(8081);
+
+    let set = move |transport: &mut HttpHandle| {
+        transport.set_header(Host::new("should.be.overwritten.url", None));
+        transport.set_header(Host::new(hostname, port));
+    };
+
+    let check = move |headers: &Headers| {
+        if let Some(host) = headers.get::<Host>() {
+            assert_eq!(host.hostname(), hostname);
+            assert_eq!(host.port(), port);
+        }
+    };
+
+    test_custom_headers(set, check);
+}
+
+#[test]
+fn set_content_type() {
+    let content_type = ContentType::xml();
+    let expected_content_type = content_type.clone();
+
+    let set = move |transport: &mut HttpHandle| {
+        transport.set_header(content_type);
+    };
+
+    let check = move |headers: &Headers| {
+        if let Some(content_type) = headers.get::<ContentType>() {
+            assert_eq!(*content_type, expected_content_type);
+        }
+    };
+
+    test_custom_headers(set, check);
+}
+
+#[test]
+fn set_content_length() {
+    let fake_content_length = ContentLength(100);
+
+    let set = move |transport: &mut HttpHandle| {
+        transport.set_header(fake_content_length);
+    };
+
+    let check = move |headers: &Headers| {
+        if let Some(content_length) = headers.get::<ContentLength>() {
+            assert_eq!(*content_length, fake_content_length);
+        }
+    };
+
+    test_custom_headers(set, check);
+}
+
+fn test_custom_headers<S, C>(set_headers: S, check_headers: C)
+where
+    S: FnOnce(&mut HttpHandle),
+    C: Fn(&Headers) + Send + Sync + 'static,
+{
+    let (mock_service, requests) = ForwardToChannel::new();
+    let (_server, port) = spawn_server(mock_service);
+
+    let transport = HttpTransport::new().unwrap();
+    let uri = format!("http://127.0.0.1:{}", port);
+    let mut transport_handle = transport.handle(&uri).unwrap();
+
+    set_headers(&mut transport_handle);
+
+    let mut reactor = Core::new().unwrap();
+    let send = transport_handle.send(Vec::new());
+
+    reactor.run(send).unwrap();
+
+    let request = requests.recv_timeout(Duration::from_secs(1)).unwrap();
+
+    check_headers(request.headers());
+}
+
+#[derive(Clone)]
+pub struct ForwardToChannel {
+    sender: mpsc::Sender<Request>,
+}
+
+impl ForwardToChannel {
+    pub fn new() -> (Self, mpsc::Receiver<Request>) {
+        let (sender, receiver) = mpsc::channel();
+        let service = ForwardToChannel { sender };
+
+        (service, receiver)
+    }
+}
+
+impl Service for ForwardToChannel {
+    type Request = Request;
+    type Response = Response;
+    type Error = hyper::Error;
+    type Future = FutureResult<Self::Response, Self::Error>;
+
+    fn call(&self, request: Request) -> Self::Future {
+        let _ = self.sender.send(request);
+
+        Ok(Response::new().with_status(StatusCode::Ok)).into_future()
+    }
+}
+
+pub struct ServerHandle(oneshot::Sender<()>);
+
+fn spawn_server(service: ForwardToChannel) -> (ServerHandle, u16) {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (started_tx, started_rx) = oneshot::channel();
+
+    thread::spawn(move || {
+        let address = "127.0.0.1:0".parse().unwrap();
+        let server = Http::new()
+            .bind(&address, move || Ok(service.clone()))
+            .unwrap();
+        let port = server.local_addr().unwrap().port();
+
+        started_tx.send(port).unwrap();
+        server.run_until(shutdown_rx.then(|_| Ok(()))).unwrap();
+    });
+
+    let server_handle = ServerHandle(shutdown_tx);
+    let server_port = started_rx.wait().unwrap();
+
+    (server_handle, server_port)
+}


### PR DESCRIPTION
HttpHandle can be configured to include custom HTTP headers in the RPC
requests it sends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/32)
<!-- Reviewable:end -->
