### PR TITLE
Add items to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Allow setting custom HTTP headers for RPC requests.
+- Allow setting a custom timeout on `HttpTransport`.
+
+### Changed
+- Reduce boxing by making the transport future an associated type on the `Transport` trait.
+- Disable TLS support by default and rename HttpTransport constructors to something that does not
+  change with activation of features.
 
 
 ## [0.3.0] - 2018-03-06

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -160,11 +160,11 @@ impl HttpTransport {
         HttpTransportBuilder::with_client(DefaultClient)
     }
 
-    #[cfg(feature = "tls")]
     /// Returns a builder to create a `HttpTransport` with support for https.
     ///
     /// The final transport that is created uses the `hyper_tls::HttpsConnector` connector, and
     /// supports both http and https connections.
+    #[cfg(feature = "tls")]
     pub fn with_tls() -> HttpTransportBuilder<DefaultTlsClient> {
         HttpTransportBuilder::with_client(DefaultTlsClient)
     }


### PR DESCRIPTION
Adding some forgotten things to the changelog to make it up to date with the current state.

Also moved a `#[cfg]` attribute to after the documentation. We didn't have any other instance of this to stay consistent with. But in other crates we usually put it after the documentation, and that has been my impression is the most common way as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/35)
<!-- Reviewable:end -->
