### PR TITLE
Test oldest supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.24.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -66,8 +66,8 @@ extern crate serde;
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
 
-use futures::Async;
 use futures::future::Future;
+use futures::Async;
 use jsonrpc_core::types::{Id, MethodCall, Params, Version};
 use serde_json::Value as JsonValue;
 
@@ -221,8 +221,8 @@ where
 {
     let id = Id::Num(transport.get_next_id());
     trace!("Serializing call to method \"{}\" with id {:?}", method, id);
-    let request_serialization_result = serialize_request(id.clone(), method, params)
-        .chain_err(|| ErrorKind::SerializeError);
+    let request_serialization_result =
+        serialize_request(id.clone(), method, params).chain_err(|| ErrorKind::SerializeError);
     match request_serialization_result {
         Err(e) => RpcRequest(Err(Some(e))),
         Ok(request_raw) => {

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use {ErrorKind, Result, ResultExt};
 use jsonrpc_core::types::{Id, Output, Version};
 use serde;
 use serde_json;
+use {ErrorKind, Result, ResultExt};
 
 /// Parses a binary response into json, extracts the "result" field and tries to deserialize that
 /// to the desired type.

--- a/http/src/client_creator.rs
+++ b/http/src/client_creator.rs
@@ -1,5 +1,5 @@
-use hyper::Body;
 use hyper::client::{Client, Connect, HttpConnector};
+use hyper::Body;
 use std::io;
 use tokio_core::reactor::Handle;
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -53,7 +53,9 @@
 //!
 //! fn main() {
 //!     let transport = HttpTransport::new().standalone().unwrap();
-//!     let transport_handle = transport.handle("https://api.fizzbuzzexample.org/rpc/").unwrap();
+//!     let transport_handle = transport
+//!         .handle("https://api.fizzbuzzexample.org/rpc/")
+//!         .unwrap();
 //!     let mut client = FizzBuzzClient::new(transport_handle);
 //!     let result1 = client.fizz_buzz(3).call().unwrap();
 //!     let result2 = client.fizz_buzz(4).call().unwrap();
@@ -80,19 +82,19 @@ extern crate hyper_tls;
 #[cfg(feature = "tls")]
 extern crate native_tls;
 
-use futures::{Async, Future, Poll, Stream};
 use futures::future::{self, Either, Select2};
 use futures::sync::{mpsc, oneshot};
-use hyper::{Client, Request, StatusCode, Uri};
+use futures::{Async, Future, Poll, Stream};
 pub use hyper::header;
+use hyper::{Client, Request, StatusCode, Uri};
 use jsonrpc_client_core::Transport;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use tokio_core::reactor::{Core, Timeout};
 pub use tokio_core::reactor::Handle;
+use tokio_core::reactor::{Core, Timeout};
 
 mod client_creator;
 pub use client_creator::*;
@@ -252,7 +254,8 @@ impl<C: ClientCreator> HttpTransportBuilder<C> {
     /// Creates the final `HttpTransport` backed by the Tokio `Handle` given to it. Use the
     /// [`standalone`](#method.standalone) method to make it create its own internal event loop.
     pub fn shared(self, handle: &Handle) -> Result<HttpTransport> {
-        let client = self.client_creator
+        let client = self
+            .client_creator
             .create(handle)
             .chain_err(|| ErrorKind::ClientCreatorError)?;
         let (request_tx, request_rx) = mpsc::unbounded();

--- a/http/tests/common/mod.rs
+++ b/http/tests/common/mod.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use futures::future::{self, Empty};
 use jsonrpc_core::{Error, IoHandler};
-use jsonrpc_http_server::{self, hyper, ServerBuilder};
 use jsonrpc_http_server::hyper::server::{Request, Response, Service};
+use jsonrpc_http_server::{self, hyper, ServerBuilder};
 
 // Generate server API trait. Actual implementation at bottom of file.
 build_rpc_trait! {

--- a/http/tests/custom_headers.rs
+++ b/http/tests/custom_headers.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 
 use futures::future::{Future, FutureResult, IntoFuture};
 use futures::sync::oneshot;
-use hyper::{Request, Response, StatusCode};
 use hyper::server::Http;
+use hyper::{Request, Response, StatusCode};
 use jsonrpc_client_http::header::{ContentLength, ContentType, Host};
 use tokio_service::Service;
 

--- a/http/tests/localhost.rs
+++ b/http/tests/localhost.rs
@@ -20,8 +20,8 @@ extern crate jsonrpc_macros;
 
 mod common;
 
-use futures::Future;
 use futures::future::Either;
+use futures::Future;
 use jsonrpc_client_http::HttpTransport;
 use std::time::Duration;
 use tokio_core::reactor::{Core, Timeout};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,4 @@
-required_version = "0.3.8"
-
 # Activation of features, almost objectively better ;)
-reorder_imports = true
-reorder_imported_names = true
-reorder_imports_in_group = true
 use_try_shorthand = true
 condense_wildcard_suffixes = true
 normalize_comments = true


### PR DESCRIPTION
The main change here is to add Travis CI runs for Rust 1.24.0. For a library it's good to keep track of the oldest supported compiler it build under. That way we can bump the major release whenever we break that compatibility.

I also updated the rustfmt settings and ran the formatter, since there has been multiple new releases since this was last formatted. The removal of `rustfmt.toml` settings is because they are now `true` by default. I copied the settings from `mullvadvpn-app`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/36)
<!-- Reviewable:end -->
