### PR TITLE
Upgrade error-chain to 0.12 and publicly export it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+## [0.5.0] - 2018-06-25
+### Changed
+- Upgrade error-chain dependency to 0.12 and publicly export it.
+
+
 ## [0.4.0] - 2018-06-18
 ### Added
 - Allow setting custom HTTP headers for RPC requests.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc-client-core"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
 description = "A crate for generating transport agnostic, auto serializing, strongly typed JSON-RPC 2.0 clients"
 readme = "../README.md"
@@ -10,7 +10,7 @@ repository = "https://github.com/mullvad/jsonrpc-client-rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-error-chain = "0.11"
+error-chain = "0.12"
 futures = "0.1"
 jsonrpc-core = "8.0"
 log = "0.4"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,7 +56,7 @@
 #![deny(missing_docs)]
 
 #[macro_use]
-extern crate error_chain;
+pub extern crate error_chain;
 #[macro_use]
 extern crate futures;
 extern crate jsonrpc_core;

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc-client-http"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
 description = "A transport implementation for jsonrpc-client-core based on Hyper and futures"
 readme = "README.md"
@@ -10,7 +10,7 @@ repository = "https://github.com/mullvad/jsonrpc-client-rs"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-error-chain = "0.11"
+error-chain = "0.12"
 futures = "0.1.15"
 hyper = "0.11"
 hyper-tls = { version = "0.1", optional = true }
@@ -18,7 +18,7 @@ native-tls = { version = "0.1", optional = true }
 log = "0.4"
 tokio-core = "0.1"
 
-jsonrpc-client-core = { version = "0.4", path = "../core" }
+jsonrpc-client-core = { version = "0.5", path = "../core" }
 
 [features]
 tls = ["hyper-tls", "native-tls"]

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -69,7 +69,7 @@
 #![deny(missing_docs)]
 
 #[macro_use]
-extern crate error_chain;
+pub extern crate error_chain;
 extern crate futures;
 extern crate hyper;
 extern crate jsonrpc_client_core;


### PR DESCRIPTION
error-chain finally fixed the warnings it produced on nightly. So upgrading. Also publicly exporting it. Otherwise it's inconvenient to reach the `display_chain()` method on the errors, if we don't re-export that trait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/37)
<!-- Reviewable:end -->
