### PR TITLE
Add IPC client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["core", "http"]
+members = ["core", "http", "ipc"]

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jsonrpc-client-ipc"
+version = "0.5.0"
+authors = ["Emīls Piņķis <emils@mullvad.net>"]
+
+[dependencies]
+futures = "0.1"
+jsonrpc-server-utils = "8"
+jsonrpc-client-core = { version = "0.5", path = "../core" }
+parity-tokio-ipc = { git = "https://github.com/mullvad/parity-tokio-ipc", rev = "add-client-support" }
+tokio = "0.1"
+tokio-core = "0.1"
+tokio-io = "0.1"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -1,0 +1,65 @@
+//! An IPC transport for JSON-RPC. Allows one to connect to a JSON-RPC server through a Unix socket
+//! or a Named Pipe on Windows.
+#![deny(missing_docs)]
+extern crate futures;
+extern crate jsonrpc_client_core;
+extern crate jsonrpc_server_utils;
+extern crate parity_tokio_ipc;
+extern crate tokio;
+extern crate tokio_core;
+extern crate tokio_io;
+
+
+use futures::sink::Sink;
+use futures::stream::Stream;
+use jsonrpc_client_core::{Client, ClientHandle};
+use jsonrpc_server_utils::codecs;
+use parity_tokio_ipc::IpcConnection;
+use tokio_core::reactor::Handle;
+use tokio_io::AsyncRead;
+
+use std::io;
+use std::path::Path;
+
+/// IpcTransport encapsulates a connection to a local IPC socket or a named pipe. It is implemented
+/// using `parity_tokio_ipc`.
+pub struct IpcTransport {
+    connection: IpcConnection,
+}
+
+impl IpcTransport {
+    /// Constructs a new IpcTransport for a given path.
+    pub fn new(path: &impl AsRef<Path>, handle: &Handle) -> io::Result<IpcTransport> {
+        Ok(IpcTransport {
+            connection: IpcConnection::connect(path, handle)?,
+        })
+    }
+
+    /// Creates a pair of a sink and a stream where the transferred item is a string representing a
+    /// single JSON object.
+    pub fn io_pair(
+        self,
+    ) -> (
+        impl Sink<SinkItem = String, SinkError = io::Error>,
+        impl Stream<Item = String, Error = io::Error>,
+    ) {
+        let codec =
+            codecs::StreamCodec::new(codecs::Separator::Empty, codecs::Separator::default());
+        self.connection.framed(codec).split()
+    }
+
+    /// Constructs a Client and a handle from the transport.
+    pub fn into_client(
+        self,
+    ) -> (
+        Client<
+            impl futures::Sink<SinkItem = String, SinkError = io::Error>,
+            impl futures::Stream<Item = String, Error = io::Error>,
+            io::Error,
+        >,
+        ClientHandle,
+    ) {
+        let (tx, rx) = self.io_pair();
+        Client::new(tx, rx)
+    }
+}


### PR DESCRIPTION
This PR adds an IPC crate. I'm unsure whether to leave this as is or remove the `IpcTransport` struct and have the same functionality with plain functions returning the Sink/Stream pair.

This crate currently depends on a self-hosted dependency - `parity-tokio-ipc = { git = "https://github.com/mullvad/parity-tokio-ipc", rev = "add-client-support" }`. The pull request for that one is here - https://github.com/NikVolf/parity-tokio-ipc/pull/5. The code in both that crate and the one's it uses `tokio-named-pipes` could do with some more work, but that's a story for a day when `2018.2` is released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/40)
<!-- Reviewable:end -->
