### PR TITLE
Add a Transport trait.

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -45,7 +45,7 @@
 //! extern crate jsonrpc_client_http;
 //!
 //! use jsonrpc_client_http::HttpTransport;
-//! use jsonrpc_client_core::Future;
+//! use jsonrpc_client_core::{Future, Transport};
 //!
 //! jsonrpc_client!(pub struct FizzBuzzClient {
 //!     /// Returns the fizz-buzz string for the given number, as a future.
@@ -89,7 +89,7 @@ use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Poll, Sink, Stream};
 pub use hyper::header;
 use hyper::{Client, Request, StatusCode, Uri};
-use jsonrpc_client_core::{Client as RpcClient, ClientHandle as RpcClientHandle};
+use jsonrpc_client_core::Transport;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -415,41 +415,6 @@ impl HttpHandle {
         request
     }
 
-    /// Creates a sink and a stream that can indefinitely transfer RPC messages. Sink will accept
-    /// strings intended to be valid JSON and the stream will return strings which are the body of
-    /// the responses from the JSONRPC server. The resulting stream and sink pair is intended to be
-    /// used to construct jsonrpc_client_core::Client.
-    pub fn io_pair(
-        self,
-    ) -> (
-        impl Sink<SinkItem = String, SinkError = Error>,
-        impl Stream<Item = String, Error = Error>,
-    ) {
-        let (tx, rx) = mpsc::channel(0);
-        let sink = tx
-            .sink_map_err(|_| Error::from(ErrorKind::TokioCoreError("Not listening for requests")))
-            .with(move |json_string: String| self.send_fut(json_string.into_bytes()));
-        let stream = rx
-            .map_err(|_| Error::from(ErrorKind::TokioCoreError("Sender closed")))
-            .and_then(|bytes| String::from_utf8(bytes).chain_err(|| ErrorKind::ParseBodyError));
-        (sink, stream)
-    }
-
-    /// Constructs a jsonrpc_client_core::Client from the HTTP transport
-    pub fn into_client(
-        self,
-    ) -> (
-        RpcClient<
-            impl futures::Sink<SinkItem = String, SinkError = Error>,
-            impl futures::Stream<Item = String, Error = Error>,
-            Error,
-        >,
-        RpcClientHandle,
-    ) {
-        let (tx, rx) = self.io_pair();
-        RpcClient::new(tx, rx)
-    }
-
     fn send_fut(&self, json_data: Vec<u8>) -> impl Future<Item = Vec<u8>, Error = Error> + Send {
         let request = self.create_request(json_data);
         let (response_tx, response_rx) = oneshot::channel();
@@ -473,6 +438,23 @@ impl HttpHandle {
     /// corresponding response.
     pub fn send(&self, json_data: Vec<u8>) -> Box<Future<Item = Vec<u8>, Error = Error> + Send> {
         Box::new(self.send_fut(json_data))
+    }
+}
+
+impl Transport for HttpHandle {
+    type Error = Error;
+    type Sink = Box<Sink<SinkItem = String, SinkError = Self::Error>>;
+    type Stream = Box<Stream<Item = String, Error = Self::Error>>;
+
+    fn io_pair(self) -> (Self::Sink, Self::Stream) {
+        let (tx, rx) = mpsc::channel(0);
+        let sink = tx
+            .sink_map_err(|_| Error::from(ErrorKind::TokioCoreError("Not listening for requests")))
+            .with(move |json_string: String| self.send_fut(json_string.into_bytes()));
+        let stream = rx
+            .map_err(|_| Error::from(ErrorKind::TokioCoreError("Sender closed")))
+            .and_then(|bytes| String::from_utf8(bytes).chain_err(|| ErrorKind::ParseBodyError));
+        (Box::new(sink), Box::new(stream))
     }
 }
 

--- a/http/tests/localhost.rs
+++ b/http/tests/localhost.rs
@@ -22,6 +22,7 @@ mod common;
 
 use futures::future::Either;
 use futures::Future;
+use jsonrpc_client_core::Transport;
 use jsonrpc_client_http::HttpTransport;
 use std::time::Duration;
 use tokio_core::reactor::{Core, Timeout};

--- a/http/tests/timeout.rs
+++ b/http/tests/timeout.rs
@@ -25,6 +25,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use futures::future::{Either, Future};
+use jsonrpc_client_core::Transport;
 use jsonrpc_client_http::{ErrorKind, HttpTransport};
 use jsonrpc_http_server::hyper::server::Http;
 use tokio_core::reactor::{Core, Timeout};

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -9,10 +9,8 @@ extern crate tokio;
 extern crate tokio_core;
 extern crate tokio_io;
 
-
-use futures::sink::Sink;
 use futures::stream::Stream;
-use jsonrpc_client_core::{Client, ClientHandle};
+use jsonrpc_client_core::Transport;
 use jsonrpc_server_utils::codecs;
 use parity_tokio_ipc::IpcConnection;
 use tokio_core::reactor::Handle;
@@ -34,32 +32,30 @@ impl IpcTransport {
             connection: IpcConnection::connect(path, handle)?,
         })
     }
+}
 
-    /// Creates a pair of a sink and a stream where the transferred item is a string representing a
-    /// single JSON object.
-    pub fn io_pair(
-        self,
-    ) -> (
-        impl Sink<SinkItem = String, SinkError = io::Error>,
-        impl Stream<Item = String, Error = io::Error>,
-    ) {
+type IpcSink = futures::stream::SplitSink<
+    tokio_io::codec::Framed<
+        parity_tokio_ipc::IpcConnection,
+        jsonrpc_server_utils::codecs::StreamCodec,
+    >,
+>;
+type IpcStream = futures::stream::SplitStream<
+    tokio_io::codec::Framed<
+        parity_tokio_ipc::IpcConnection,
+        jsonrpc_server_utils::codecs::StreamCodec,
+    >,
+>;
+
+
+impl Transport for IpcTransport {
+    type Error = io::Error;
+    type Sink = IpcSink;
+    type Stream = IpcStream;
+
+    fn io_pair(self) -> (Self::Sink, Self::Stream) {
         let codec =
             codecs::StreamCodec::new(codecs::Separator::Empty, codecs::Separator::default());
         self.connection.framed(codec).split()
-    }
-
-    /// Constructs a Client and a handle from the transport.
-    pub fn into_client(
-        self,
-    ) -> (
-        Client<
-            impl futures::Sink<SinkItem = String, SinkError = io::Error>,
-            impl futures::Stream<Item = String, Error = io::Error>,
-            io::Error,
-        >,
-        ClientHandle,
-    ) {
-        let (tx, rx) = self.io_pair();
-        Client::new(tx, rx)
     }
 }


### PR DESCRIPTION
During integration, the 3 type parameters for `core::Client<W,R,E>` get a bit hard to use, and the construction is a bit ad-hoc. Thus, a `Transport` trait has been reintroduced. This means that there's some boxing now that wasn't present in the HTTP crate before, but the rest of the code is much cleaner, and the libraries will be far easier to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/41)
<!-- Reviewable:end -->
