### PR TITLE
Small fixes in send_notification

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -167,7 +167,7 @@ impl ClientHandle {
 
 
     /// Sends a notificaiton to the Server.
-    pub fn send_notification<P, T>(
+    pub fn send_notification(
         &self,
         method: String,
         parameters: &impl serde::Serialize,
@@ -176,12 +176,12 @@ impl ClientHandle {
 
         let rpc_chan = self.rpc_call_chan.clone();
 
-        future::result(serialize_parameters(&parameters))
+        future::result(serialize_parameters(parameters))
             .and_then(|params| {
                 rpc_chan
                     .send(ClientCall::Notification(method, params, tx))
                     .map_err(|_| ErrorKind::Shutdown.into())
-            }).then(|_| rx.map_err(|_| Error::from(ErrorKind::Shutdown)))
+            }).and_then(|_| rx.map_err(|_| Error::from(ErrorKind::Shutdown)))
             .flatten()
     }
 }


### PR DESCRIPTION
I found some small possible cleanups in this method.

And also, changing from `then` to `and_then` should remove a case of where the first error was just ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/42)
<!-- Reviewable:end -->
