### PR TITLE
Depend on upstream IPC library

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Emīls Piņķis <emils@mullvad.net>"]
 futures = "0.1"
 jsonrpc-server-utils = "8"
 jsonrpc-client-core = { version = "0.5", path = "../core" }
-parity-tokio-ipc = { git = "https://github.com/mullvad/parity-tokio-ipc", rev = "add-client-support" }
+parity-tokio-ipc = { git = "https://github.com/NikVolf/parity-tokio-ipc", rev = "stable" }
 tokio = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
This PR updates the dependency `parity-tokio-ipc` to point towards the upstream repository. This is done so that it is kept up to date with what the server uses. Also, it seems that depending on an older version of the library introduces breakage on windows, which I had not foreseen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/43)
<!-- Reviewable:end -->
