### PR TITLE
Reduce build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ environment:
   # don't need
   matrix:
     # MinGW
-    - TARGET: i686-pc-windows-gnu
     - TARGET: x86_64-pc-windows-gnu
 
     # MSVC
@@ -19,12 +18,8 @@ environment:
     - TARGET: x86_64-pc-windows-msvc
 
     # Testing other channels
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: beta
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: beta
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: nightly
 


### PR DESCRIPTION
Running 8 builds where each can take up to 20 minutes is a bit excessive
as it the build queue for other projects on appveyor. I've removed some of the GNU toolchain build targets, as I presume they would be the least popular ones on Windows.
https://ci.appveyor.com/project/Mullvad/jsonrpc-client-rs/build/1.0.244

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/44)
<!-- Reviewable:end -->
