### PR TITLE
Add client support for responding to RPCs and notificaitons.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ jsonrpc-core = "8.0"
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 
 
 [badges]

--- a/core/src/id_generator.rs
+++ b/core/src/id_generator.rs
@@ -1,0 +1,24 @@
+use jsonrpc_core::types::Id;
+
+#[derive(Debug)]
+pub struct IdGenerator {
+    next_id: u64,
+}
+
+impl IdGenerator {
+    pub fn new() -> IdGenerator {
+        IdGenerator { next_id: 1 }
+    }
+
+    pub fn next(&mut self) -> Id {
+        let id = Id::Num(self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    pub fn next_int(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -83,6 +83,9 @@ use std::collections::HashMap;
 #[macro_use]
 mod macros;
 
+mod id_generator;
+use id_generator::IdGenerator;
+
 /// Module containing an example client. To show in the docs what a generated struct look like.
 pub mod example;
 
@@ -186,22 +189,6 @@ impl ClientHandle {
     }
 }
 
-#[derive(Debug)]
-struct IdGenerator {
-    next_id: u64,
-}
-
-impl IdGenerator {
-    fn new() -> IdGenerator {
-        IdGenerator { next_id: 1 }
-    }
-
-    fn next(&mut self) -> Id {
-        let id = Id::Num(self.next_id);
-        self.next_id += 1;
-        id
-    }
-}
 
 /// A Transport allows one to send and receive JSON objects to a JSON-RPC server.
 pub trait Transport: Sized {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -88,6 +88,7 @@ mod macros;
 mod id_generator;
 use id_generator::IdGenerator;
 
+mod select_weak;
 mod server;
 
 /// Module containing an example client. To show in the docs what a generated struct look like.

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! jsonrpc_client {
                     let raw_params = expand_params!($($arg_name,)*);
                     let params = $crate::serialize_parameters(&raw_params);
                     let (tx, rx) = $crate::oneshot::channel();
-                    let client_call = params.map(|p| $crate::ClientCall::RpcCall(method, p, tx));
+                    let client_call = params.map(|p| $crate::OutgoingMessage::RpcCall(method, p, tx));
                     $selff.client.send_client_call(client_call, rx)
                 }
             )*

--- a/core/src/select_weak.rs
+++ b/core/src/select_weak.rs
@@ -1,0 +1,83 @@
+use futures::stream::{Fuse, Stream};
+use futures::{Async, Poll};
+
+pub trait SelectWithWeakExt: Stream + Sized {
+    fn select_with_weak<S>(self, weak: S) -> SelectWithWeak<Self, S>
+    where
+        S: Stream<Item = Self::Item, Error = Self::Error>;
+}
+
+impl<T: Stream> SelectWithWeakExt for T {
+    fn select_with_weak<S>(self, weak: S) -> SelectWithWeak<Self, S>
+    where
+        S: Stream<Item = Self::Item, Error = Self::Error>,
+        Self: Sized,
+    {
+        SelectWithWeak {
+            strong: self.fuse(),
+            weak: weak.fuse(),
+            use_strong: false,
+            weak_done: false,
+        }
+    }
+}
+
+/// An adapter for merging the output of two streams.
+///
+/// The merged stream produces items from either of the underlying streams as
+/// they become available, and the streams are polled in a round-robin fashion.
+/// Errors, however, are not merged: you get at most one error at a time.
+///
+/// Finishes when strong stream finishes
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct SelectWithWeak<S1, S2> {
+    strong: Fuse<S1>,
+    weak: Fuse<S2>,
+    use_strong: bool,
+    weak_done: bool,
+}
+
+impl<S1, S2> SelectWithWeak<S1, S2>
+where
+    S1: Stream,
+    S2: Stream<Item = S1::Item, Error = S1::Error>,
+{
+    fn check_weak(&mut self) -> Poll<Option<S1::Item>, S1::Error> {
+        if self.weak_done {
+            return Ok(Async::NotReady);
+        };
+        match self.weak.poll() {
+            Ok(Async::Ready(None)) => {
+                self.weak_done = true;
+                Ok(Async::NotReady)
+            }
+            other => other,
+        }
+    }
+}
+
+impl<S1, S2> Stream for SelectWithWeak<S1, S2>
+where
+    S1: Stream,
+    S2: Stream<Item = S1::Item, Error = S1::Error>,
+{
+    type Item = S1::Item;
+    type Error = S1::Error;
+
+    fn poll(&mut self) -> Poll<Option<S1::Item>, S1::Error> {
+        if !self.use_strong {
+            self.use_strong = true;
+            match self.check_weak() {
+                Ok(Async::NotReady) => self.strong.poll(),
+                other => other,
+            }
+        } else {
+            self.use_strong = false;
+            match self.strong.poll() {
+                Ok(Async::NotReady) => self.check_weak(),
+                other => other,
+            }
+        }
+    }
+}

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -1,0 +1,222 @@
+use super::{ClientCall, Error, ErrorKind, Result};
+use id_generator::IdGenerator;
+
+use futures::future::Either;
+use futures::{future, stream, sync::mpsc, Async, Future, Sink, Stream};
+pub use jsonrpc_core::types;
+use jsonrpc_core::types::{
+    Call, Error as RpcError, Failure, Id, MethodCall, Notification, Output, Request, Response,
+    Version,
+};
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+
+type MethodHandler = Box<Fn(MethodCall) -> Box<Future<Item = Output, Error = Error>>>;
+type NotificationHandler = Box<Fn(Notification) -> Box<Future<Item = (), Error = Error>>>;
+
+
+/// A callback to be called in response to either a notification or a method call coming in from
+/// the server.
+pub enum Handler {
+    /// Method handler.
+    Method(MethodHandler),
+    /// Notification handler.
+    Notification(NotificationHandler),
+}
+
+impl Handler {
+    fn description(&self) -> &'static str {
+        match self {
+            Handler::Method(_) => "method",
+            Handler::Notification(_) => "notification",
+        }
+    }
+}
+
+/// A collection callbacks to be executed for specific notification and method JSON-RPC requests.
+#[derive(Clone)]
+pub struct Handlers {
+    handlers: Arc<RwLock<HashMap<String, Handler>>>,
+}
+
+impl Handlers {
+    fn new() -> Self {
+        Handlers {
+            handlers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Add a handler for a given method or notification.
+    pub fn add(&self, method: String, handler: Handler) {
+        let mut map = self.handlers.write().unwrap();
+        map.insert(method, handler);
+    }
+
+    /// Remove a handler for a given method or notification.
+    pub fn remove(&self, method: &str) {
+        let mut map = self.handlers.write().unwrap();
+        map.remove(method);
+    }
+
+    fn handle_single_call(&mut self, call: Call) -> PendingCall {
+        match call {
+            Call::MethodCall(method_call) => self.handle_method_call(method_call),
+            Call::Notification(notification) => self.handle_notification_call(notification),
+            Call::Invalid(id) => {
+                Box::new(future::ok(Some(failure(id, RpcError::invalid_request()))))
+            }
+        }
+    }
+
+    fn handle_method_call(&self, method_call: MethodCall) -> PendingCall {
+        let handlers = self.handlers.read().unwrap();
+
+        match handlers.get(&method_call.method) {
+            Some(Handler::Method(handler)) => Box::new(handler(method_call).map(Some)),
+            _ => Box::new(future::ok(Some(failure(
+                method_call.id,
+                RpcError::method_not_found(),
+            )))),
+        }
+    }
+
+    fn handle_notification_call(&self, notification: Notification) -> PendingCall {
+        let handlers = self.handlers.read().unwrap();
+        match handlers.get(&notification.method) {
+            Some(Handler::Notification(handler)) => Box::new(handler(notification).map(|_| None)),
+            _ => Box::new(future::ok(None)),
+        }
+    }
+}
+
+impl fmt::Debug for Handlers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Handlers{{\n")?;
+        match self.handlers.read() {
+            Ok(handlers) => {
+                for (method_name, callback) in handlers.iter() {
+                    write!(f, "\t{} - {}\n", method_name, callback.description())?;
+                }
+            }
+            Err(e) => {
+                write!(f, "ERROR - POISONED MUTEX  - {}\n", e)?;
+            }
+        }
+        write!(f, "}}")
+    }
+}
+
+fn failure(id: Id, error: RpcError) -> Output {
+    Output::Failure(Failure {
+        jsonrpc: Some(Version::V2),
+        error,
+        id,
+    })
+}
+
+/// Default server implementation.
+pub struct Server {
+    handlers: Handlers,
+    pending_futures: BTreeMap<u64, DrivableCall>,
+    id_generator: IdGenerator,
+}
+
+type PendingCall = Box<Future<Item = Option<Output>, Error = Error>>;
+type DrivableCall = Box<Future<Item = (), Error = Error>>;
+
+impl Server {
+    /// Constructs a new server.
+    pub fn new() -> Self {
+        Self {
+            handlers: Handlers::new(),
+            pending_futures: BTreeMap::new(),
+            id_generator: IdGenerator::new(),
+        }
+    }
+
+    fn push_future(&mut self, driveable_future: DrivableCall) {
+        self.pending_futures
+            .insert(self.id_generator.next_int(), driveable_future);
+    }
+
+    /// Access handler collection to add or remove handlers.
+    pub fn get_handlers(&self) -> Handlers {
+        self.handlers.clone()
+    }
+}
+
+impl Future for Server {
+    type Item = ();
+    type Error = Error;
+
+    fn poll(&mut self) -> Result<Async<()>> {
+        let polled: Result<Vec<(u64, Async<()>)>> = self
+            .pending_futures
+            .iter_mut()
+            .map(|(key, fut)| Ok((*key, fut.poll()?)))
+            .collect();
+        for key in polled?.iter().filter_map(|(key, res)| match res {
+            Async::Ready(_) => Some(key),
+            _ => None,
+        }) {
+            self.pending_futures.remove(key);
+        }
+
+        Ok(Async::NotReady)
+    }
+}
+
+
+impl ServerHandler for Server {
+    fn process_request(&mut self, request: Request, sink: mpsc::Sender<ClientCall>) {
+        let driveable_future = match request {
+            Request::Single(req) => {
+                let driveable_future =
+                    self.handlers
+                        .handle_single_call(req)
+                        .and_then(move |output| match output {
+                            Some(response) => Either::A(
+                                sink.send(ClientCall::Response(Response::Single(response)))
+                                    .map_err(|_| ErrorKind::Shutdown.into())
+                                    .map(|_| ()),
+                            ),
+                            None => Either::B(future::ok(())),
+                        });
+                Either::A(driveable_future)
+            }
+
+            Request::Batch(requests) => {
+                let fut = stream::futures_unordered(
+                    requests
+                        .into_iter()
+                        .map(|call| self.handlers.handle_single_call(call)),
+                ).filter_map(|maybe_response| maybe_response)
+                .collect()
+                .and_then(|results| {
+                    if results.len() > 0 {
+                        Either::A(
+                            sink.send(ClientCall::Response(Response::Batch(results)))
+                                .map_err(|_| ErrorKind::Shutdown.into())
+                                .map(|_| ()),
+                        )
+                    } else {
+                        Either::B(future::ok(()))
+                    }
+                });
+                Either::B(fut)
+            }
+        };
+        self.push_future(Box::new(driveable_future));
+    }
+}
+
+/// The core client is able to use whatever server that implements this trait. The handler is
+/// expected to be asynchronous, so it has to implement the Future trait as well.
+pub trait ServerHandler: Future<Item = (), Error = Error> {
+    /// Handles a request coming in from the server, optionally sending a result back to the
+    /// server.
+    fn process_request(&mut self, Request, sender: mpsc::Sender<ClientCall>);
+}

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -1,4 +1,4 @@
-use super::{ClientCall, Error, ErrorKind, Result};
+use super::{OutgoingMessage, Error, ErrorKind, Result};
 use id_generator::IdGenerator;
 
 use futures::future::Either;
@@ -171,7 +171,7 @@ impl Future for Server {
 
 
 impl ServerHandler for Server {
-    fn process_request(&mut self, request: Request, sink: mpsc::Sender<ClientCall>) {
+    fn process_request(&mut self, request: Request, sink: mpsc::Sender<OutgoingMessage>) {
         let driveable_future = match request {
             Request::Single(req) => {
                 let driveable_future =
@@ -179,7 +179,7 @@ impl ServerHandler for Server {
                         .handle_single_call(req)
                         .and_then(move |output| match output {
                             Some(response) => Either::A(
-                                sink.send(ClientCall::Response(Response::Single(response)))
+                                sink.send(OutgoingMessage::Response(Response::Single(response)))
                                     .map_err(|_| ErrorKind::Shutdown.into())
                                     .map(|_| ()),
                             ),
@@ -198,7 +198,7 @@ impl ServerHandler for Server {
                 .and_then(|results| {
                     if results.len() > 0 {
                         Either::A(
-                            sink.send(ClientCall::Response(Response::Batch(results)))
+                            sink.send(OutgoingMessage::Response(Response::Batch(results)))
                                 .map_err(|_| ErrorKind::Shutdown.into())
                                 .map(|_| ()),
                         )
@@ -218,5 +218,5 @@ impl ServerHandler for Server {
 pub trait ServerHandler: Future<Item = (), Error = Error> {
     /// Handles a request coming in from the server, optionally sending a result back to the
     /// server.
-    fn process_request(&mut self, Request, sender: mpsc::Sender<ClientCall>);
+    fn process_request(&mut self, Request, sender: mpsc::Sender<OutgoingMessage>);
 }


### PR DESCRIPTION
This PR adds client support for responding to RPCs and acting upon notifications received from the server.
It might still be slightly rough around the edges, but this exposes a nice set of primitives that can be used to implement subscription support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/45)
<!-- Reviewable:end -->
