### PR TITLE
Update parity-tokio-ipc dependency

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Emīls Piņķis <emils@mullvad.net>"]
 futures = "0.1"
 jsonrpc-server-utils = "8"
 jsonrpc-client-core = { version = "0.5", path = "../core" }
-parity-tokio-ipc = { git = "https://github.com/NikVolf/parity-tokio-ipc", rev = "stable" }
+parity-tokio-ipc = { git = "https://github.com/NikVolf/parity-tokio-ipc", rev = "master" }
 tokio = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -6,14 +6,13 @@ extern crate jsonrpc_client_core;
 extern crate jsonrpc_server_utils;
 extern crate parity_tokio_ipc;
 extern crate tokio;
-extern crate tokio_core;
 extern crate tokio_io;
 
 use futures::stream::Stream;
 use jsonrpc_client_core::Transport;
 use jsonrpc_server_utils::codecs;
 use parity_tokio_ipc::IpcConnection;
-use tokio_core::reactor::Handle;
+use tokio::reactor::Handle;
 use tokio_io::AsyncRead;
 
 use std::io;


### PR DESCRIPTION
A recent change in `parity-tokio-ipc` broke our `jsonrpc-client-ipc` crate. This PR fixes the changes. These changes will unfortunately require more changes downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/46)
<!-- Reviewable:end -->
