### PR TITLE
allow disabling of version check

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 
+[features]
+disable_version_check = []
 
 [badges]
 travis-ci = { repository = "mullvad/jsonrpc-client-rs" }

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -19,10 +19,10 @@ where
 {
     let response: Output = serde_json::from_slice(response_raw)
         .chain_err(|| ErrorKind::ResponseError("Not valid json"))?;
-    ensure!(
+    /*ensure!(
         response.version() == Some(Version::V2),
         ErrorKind::ResponseError("Not JSON-RPC 2.0 compatible")
-    );
+    );*/
     ensure!(
         response.id() == expected_id,
         ErrorKind::ResponseError("Response id not equal to request id")

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -29,7 +29,7 @@ where
     );
     match response {
         Output::Success(success) => {
-            trace!("Received json result: {}", success.result);
+            println!("Received json result: {}", success.result);
             serde_json::from_value(success.result)
                 .chain_err(|| ErrorKind::ResponseError("Not valid for target type"))
         }

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -29,7 +29,7 @@ where
     );
     match response {
         Output::Success(success) => {
-            println!("Received json result: {}", success.result);
+            trace!("Received json result: {}", success.result);
             serde_json::from_value(success.result)
                 .chain_err(|| ErrorKind::ResponseError("Not valid for target type"))
         }

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -19,10 +19,11 @@ where
 {
     let response: Output = serde_json::from_slice(response_raw)
         .chain_err(|| ErrorKind::ResponseError("Not valid json"))?;
-    /*ensure!(
+    #[cfg(not(feature = "disable_version_check"))]
+    ensure!(
         response.version() == Some(Version::V2),
         ErrorKind::ResponseError("Not JSON-RPC 2.0 compatible")
-    );*/
+    );
     ensure!(
         response.id() == expected_id,
         ErrorKind::ResponseError("Response id not equal to request id")


### PR DESCRIPTION
there are some json rpc servers out there that do not return a version but are otherwise json rpc 2.0 compliant. this feature allows them to be used.