### PR TITLE
Segregate transports by duplex support

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -215,14 +215,17 @@ pub trait Transport: Sized {
 
     /// Creates a Client and a ClientHandle from a transport implementation.
     fn into_client(self) -> (Client<Self, server::Server>, ClientHandle) {
-        self.with_server(server::Server::new())
+        Client::new(self)
     }
+}
 
-    /// Creates a Client and a ClientHandle from a transport implementation and provides a custom
-    /// server implementation.
-    fn with_server<S: server::ServerHandler>(self, s: S) -> (Client<Self, S>, ClientHandle) {
-        let (tx, rx) = self.io_pair();
-        Client::new(tx, rx, s)
+/// A transport trait that should be implemented only for transports that support full duplex
+/// communication between the client and the server. DuplexTransport implementors allow the user of
+/// the library to specify a server handler.
+pub trait DuplexTransport: Transport {
+    /// Constructs a new client with the provided server handler.
+    fn with_server<S: server::ServerHandler>(self, s:S) -> (Client<Self, S>, ClientHandle) {
+        Client::new_with_server(self, s)
     }
 }
 
@@ -263,18 +266,31 @@ enum IncomingMessage {
     Request(Request),
 }
 
-impl<T: Transport, S: server::ServerHandler> Client<T, S> {
+impl<T: Transport> Client<T, server::Server> {
     /// To create a new Client, one must provide a transport sink and stream pair. The transport
     /// sinks are expected to send and receive strings which should hold exactly one JSON
     /// object. If any error is returned by either the sink or the stream, this future will fail,
     /// and all pending requests will be dropped. If the transport stream finishes, this future
     /// will resolve without an error. The client will resolve once all of it's handles and
     /// corresponding futures get resolved.
-    pub fn new(
-        transport_tx: T::Sink,
-        transport_rx: T::Stream,
+    pub fn new(transport: T) -> (Self, ClientHandle) {
+        Self::new_with_server(transport, server::Server::new())
+    }
+}
+
+impl<T: DuplexTransport, S: server::ServerHandler> Client<T, S> {
+    /// Creates a new client from the provided transport and server implementations.
+    pub fn with_server(transport: T, server: S) -> (Self, ClientHandle) {
+        Self::new_with_server(transport, server)
+    }
+}
+
+impl<T: Transport, S: server::ServerHandler> Client<T, S> {
+    fn new_with_server(
+        transport: T,
         server_handler: S,
     ) -> (Self, ClientHandle) {
+        let (transport_tx, transport_rx) = transport.io_pair();
         let (client_handle_tx, client_handle_rx) = mpsc::channel(0);
         let (server_response_tx, server_response_rx) = mpsc::channel(0);
 

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -9,7 +9,7 @@ extern crate tokio;
 extern crate tokio_io;
 
 use futures::stream::Stream;
-use jsonrpc_client_core::Transport;
+use jsonrpc_client_core::{Transport, DuplexTransport};
 use jsonrpc_server_utils::codecs;
 use parity_tokio_ipc::IpcConnection;
 use tokio::reactor::Handle;
@@ -58,3 +58,5 @@ impl Transport for IpcTransport {
         self.connection.framed(codec).split()
     }
 }
+
+impl DuplexTransport for IpcTransport {}


### PR DESCRIPTION
These changes make it so that unless a transport explicitly implements `DuplexTransport`, the user won't be able to use any of the `JSON-RPC` functionality that requires the server to be able to arbitrarily send requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/49)
<!-- Reviewable:end -->
