### PR TITLE
Use nikvolf in url instead of NikVolf

### DIFF
--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Emīls Piņķis <emils@mullvad.net>"]
 futures = "0.1"
 jsonrpc-server-utils = "8"
 jsonrpc-client-core = { version = "0.5", path = "../core" }
-parity-tokio-ipc = { git = "https://github.com/NikVolf/parity-tokio-ipc", rev = "master" }
+parity-tokio-ipc = { git = "https://github.com/nikvolf/parity-tokio-ipc" }
 tokio = "0.1"
 tokio-core = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
Changing so we use the same git url as the other dependencies depending on `parity-tokio-ipc`. Otherwise, currently `mullvad-daemon` has to compile and link this library twice, since it thinks it's different crates. See the `Cargo.lock` in our main repo :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/50)
<!-- Reviewable:end -->
