### PR TITLE
Use a more generic Executor trait

### DIFF
--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -10,5 +10,5 @@ error-chain = "0.12"
 futures = "0.1.24"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-tokio = "0.1"
+tokio = "0.1.15"
 log = "0.4"


### PR DESCRIPTION
~A lot~ _something_ has changed in the tokio ecosystem since I was last working on this crate. As such, we can have the subscription types be slightly more generic, allowing us to use the single threaded runtime in `mullvad-ipc-client` to run subscriptions.
There are also some formatting changes in here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/54)
<!-- Reviewable:end -->
