### PR TITLE
Add hyper 0.12 based HTTP transport implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["core", "http", "ipc", "pubsub", "utils"]
+members = ["core", "http", "newhttp", "ipc", "pubsub", "utils"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -191,14 +191,15 @@ impl ClientHandle {
                 rpc_chan
                     .send(OutgoingMessage::Notification(method, params, tx))
                     .map_err(|_| ErrorKind::Shutdown.into())
-            }).and_then(|_| rx.map_err(|_| Error::from(ErrorKind::Shutdown)))
+            })
+            .and_then(|_| rx.map_err(|_| Error::from(ErrorKind::Shutdown)))
             .flatten()
     }
 }
 
 
 /// A Transport allows one to send and receive JSON objects to a JSON-RPC server.
-pub trait Transport: Sized + Send{
+pub trait Transport: Sized + Send {
     /// A transport specific error
     type Error: ::std::error::Error + Send + 'static;
     /// A stream of strings, each of which represent a single JSON value that is either an array or

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -8,7 +8,7 @@
 
 /// The main macro of this crate. Generates JSON-RPC 2.0 client structs with automatic serialization
 /// and deserialization. Method calls get correct types automatically.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! jsonrpc_client {
     (
         $(#[$struct_attr:meta])*
@@ -34,7 +34,7 @@ macro_rules! jsonrpc_client {
                 pub fn $method(&mut $selff $(, $arg_name: $arg_ty)*)
                     -> impl $crate::Future<Item = $return_ty, Error = $crate::Error> + 'static
                 {
-                    let method = String::from(stringify!($method));
+                    let method = String::from(stringify_internal!($method));
                     let raw_params = expand_params!($($arg_name,)*);
                     let params = $crate::serialize_parameters(&raw_params);
                     let (tx, rx) = $crate::oneshot::channel();
@@ -46,6 +46,11 @@ macro_rules! jsonrpc_client {
     )
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! stringify_internal {
+    ($($t:tt)*) => (stringify!($($t)*))
+}
 
 /// Expands a variable list of parameters into its serializable form. Is needed to make the params
 /// of a nullary method equal to `[]` instead of `()` and thus make sure it serializes to `[]`

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -375,7 +375,8 @@ impl ServerHandler for Server {
                     requests
                         .into_iter()
                         .map(|call| self.handler_map.handle_single_call(call)),
-                ).filter_map(|maybe_response| maybe_response)
+                )
+                .filter_map(|maybe_response| maybe_response)
                 .collect()
                 .and_then(|results| {
                     if results.len() > 0 {

--- a/newhttp/Cargo.toml
+++ b/newhttp/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "jsonrpc-client-newhttp"
+version = "0.5.0"
+authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <linus@mullvad.net>"]
+description = "A transport implementation for jsonrpc-client-core based on Hyper"
+#readme = "README.md"
+keywords = ["jsonrpc", "rpc", "client", "http", "https"]
+categories = ["network-programming", "web-programming", "web-programming::http-client"]
+repository = "https://github.com/mullvad/jsonrpc-client-rs"
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[dependencies]
+err-derive = "0.1.5"
+futures = "0.1.25"
+hyper = "0.12"
+log = "0.4"
+jsonrpc-client-core = { version = "0.5", path = "../core" }
+tokio-timer = "0.2.10"
+
+[dev-dependencies]
+hyper-rustls = "0.16"
+tokio = "0.1"
+env_logger = "0.6.0"
+
+[badges]
+travis-ci = { repository = "mullvad/jsonrpc-client-rs" }
+appveyor = { repository = "mullvad/jsonrpc-client-rs" }

--- a/newhttp/Cargo.toml
+++ b/newhttp/Cargo.toml
@@ -22,6 +22,10 @@ tokio-timer = "0.2.10"
 hyper-rustls = "0.16"
 tokio = "0.1"
 env_logger = "0.6.0"
+jsonrpc-core = "10.0"
+jsonrpc-derive = "10.0"
+jsonrpc-http-server = "10.0"
+serde = "1.0"
 
 [badges]
 travis-ci = { repository = "mullvad/jsonrpc-client-rs" }

--- a/newhttp/examples/simple.rs
+++ b/newhttp/examples/simple.rs
@@ -1,0 +1,39 @@
+use futures::Future;
+use hyper::{Client, Uri};
+use jsonrpc_client_core::Transport;
+use std::error::Error;
+
+fn main() {
+    env_logger::init();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let https = hyper_rustls::HttpsConnector::new(4);
+    let client: Client<_, hyper::Body> = Client::builder().build(https);
+
+    let jsonrpc_transport = jsonrpc_client_newhttp::HttpTransport::new(client, None);
+
+    let uri = "https://api.mullvad.net/rpc/".parse::<Uri>().unwrap();
+    let (jsonrpc_client, client_handle) = jsonrpc_transport.handle(uri).into_client();
+
+    rt.spawn(jsonrpc_transport);
+    rt.spawn(jsonrpc_client.map_err(|e| {
+        let mut msg = e.to_string();
+        let mut source = e.source();
+        while let Some(s) = source {
+            msg.push_str("\nCaused by: ");
+            msg.push_str(&s.to_string());
+            source = s.source();
+        }
+        log::error!("Error in JSON-RPC 2.0 client: {}", msg);
+    }));
+
+    let mut app_version_proxy = AppVersionProxy::new(client_handle);
+    let is_supported = rt.block_on(app_version_proxy.is_app_version_supported("bogus version"));
+    match is_supported {
+        Ok(is_supported) => println!("Is version supported? {}", is_supported),
+        Err(e) => eprintln!("Error processing request: {}", e),
+    }
+}
+
+jsonrpc_client_core::jsonrpc_client!(pub struct AppVersionProxy {
+    pub fn is_app_version_supported(&mut self, version: &str) -> Future<bool>;
+});

--- a/newhttp/src/lib.rs
+++ b/newhttp/src/lib.rs
@@ -1,0 +1,154 @@
+use futures::{
+    future,
+    sync::{mpsc, oneshot},
+    Future, Poll, Sink, Stream,
+};
+pub use hyper;
+use hyper::{client::connect::Connect, Body, Client, Request, Uri};
+use std::time::Duration;
+
+mod timeout;
+
+pub struct HttpTransport {
+    future: Box<dyn Future<Item = (), Error = ()> + Send>,
+    handle_tx: mpsc::UnboundedSender<(Request<Body>, oneshot::Sender<Result<Vec<u8>, Error>>)>,
+}
+
+impl HttpTransport {
+    pub fn new<C: Connect + 'static>(
+        client: Client<C, hyper::Body>,
+        timeout: Option<Duration>,
+    ) -> Self {
+        let (tx, rx) = mpsc::unbounded();
+        Self {
+            future: Box::new(Self::create_request_processing_future(rx, client, timeout)),
+            handle_tx: tx,
+        }
+    }
+
+    pub fn handle(&self, uri: Uri) -> HttpHandle {
+        HttpHandle {
+            request_tx: self.handle_tx.clone(),
+            uri,
+        }
+    }
+
+    fn create_request_processing_future<C: Connect + 'static>(
+        request_rx: mpsc::UnboundedReceiver<(
+            Request<Body>,
+            oneshot::Sender<Result<Vec<u8>, Error>>,
+        )>,
+        client: Client<C, hyper::Body>,
+        timeout: Option<Duration>,
+    ) -> impl Future<Item = (), Error = ()> + Send {
+        request_rx.for_each(move |(request, response_tx)| {
+            log::trace!("Sending request to {}", request.uri());
+            let request = client.request(request);
+            timeout::OptionalTimeout::new(request, timeout)
+                .map_err(|e| {
+                    if e.is_inner() {
+                        Error::HyperError(e.into_inner().unwrap())
+                    } else if e.is_timer() {
+                        Error::TimerError(e.into_timer().unwrap())
+                    } else {
+                        Error::TimeoutError
+                    }
+                })
+                .and_then(|response| {
+                    let status = response.status();
+                    log::debug!("Got response with status {}", status);
+                    if status == hyper::StatusCode::OK {
+                        Ok(response)
+                    } else {
+                        Err(Error::HttpResponseError(status))
+                    }
+                })
+                .and_then(|response| {
+                    response
+                        .into_body()
+                        .concat2()
+                        .map_err(|e| Error::HyperError(e))
+                })
+                .map(|response_body| response_body.to_vec())
+                .then(move |response_result| {
+                    if response_tx.send(response_result).is_err() {
+                        log::warn!("Unable to send response back to caller");
+                    }
+                    Ok(()) as Result<(), ()>
+                })
+        })
+    }
+}
+
+impl Future for HttpTransport {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.future.poll()
+    }
+}
+
+pub struct HttpHandle {
+    request_tx: mpsc::UnboundedSender<(Request<Body>, oneshot::Sender<Result<Vec<u8>, Error>>)>,
+    uri: Uri,
+}
+
+impl HttpHandle {
+    /// Creates a Hyper POST request with JSON content type and the given body data.
+    fn create_request(&self, body: Vec<u8>) -> Request<Body> {
+        let mut request = hyper::Request::post(self.uri.clone());
+        request.header(hyper::header::CONTENT_TYPE, "application/json");
+        request.header(hyper::header::CONTENT_LENGTH, body.len());
+        request
+            .body(Body::from(body))
+            .expect("Failed to create HTTP request")
+    }
+
+    fn send(&self, json_data: Vec<u8>) -> impl Future<Item = Vec<u8>, Error = Error> + Send {
+        let request = self.create_request(json_data);
+        let (response_tx, response_rx) = oneshot::channel();
+        future::result(self.request_tx.unbounded_send((request, response_tx)))
+            .map_err(|_e| Error::TransportClosedError)
+            .and_then(move |_| response_rx.map_err(|_e| Error::TransportClosedError))
+            .flatten()
+    }
+}
+
+impl jsonrpc_client_core::Transport for HttpHandle {
+    type Error = Error;
+    type Sink = Box<dyn Sink<SinkItem = String, SinkError = Self::Error> + Send>;
+    type Stream = Box<dyn Stream<Item = String, Error = Self::Error> + Send>;
+
+    fn io_pair(self) -> (Self::Sink, Self::Stream) {
+        let (tx, rx) = mpsc::channel(0);
+        let sink = tx
+            .sink_map_err(|_| Error::TransportClosedError)
+            .with(move |json: String| self.send(json.into_bytes()));
+        let stream = rx
+            .map_err(|_| Error::TransportClosedError)
+            .and_then(|bytes| String::from_utf8(bytes).map_err(|e| Error::ParseBodyError(e)));
+        (Box::new(sink), Box::new(stream))
+    }
+}
+
+#[derive(Debug, err_derive::Error)]
+pub enum Error {
+    #[error(display = "The HTTP transport processor has stopped")]
+    TransportClosedError,
+
+    #[error(display = "Error in HTTP client")]
+    HyperError(#[error(cause)] hyper::Error),
+
+    #[error(display = "Error in timeout timer")]
+    TimerError(#[error(cause)] tokio_timer::Error),
+
+    #[error(display = "Request timed out")]
+    TimeoutError,
+
+    #[error(display = "Unexpected HTTP status code in response: {}", _0)]
+    HttpResponseError(hyper::StatusCode),
+
+    #[error(display = "Response body is not valid UTF-8")]
+    ParseBodyError(#[error(cause)] std::string::FromUtf8Error),
+}

--- a/newhttp/src/timeout.rs
+++ b/newhttp/src/timeout.rs
@@ -1,0 +1,40 @@
+use futures::{Future, Poll};
+use std::time::Duration;
+use tokio_timer::Timeout;
+
+pub use tokio_timer::timeout::Error;
+
+/// Wraps a `Future` and optionally, give it a time limit to complete within.
+/// This is a quite thin wrapper around `tokio_timer::Timeout` with the difference
+/// that the timeout deadline is optional. Allowing static dispatch over a collection
+/// of futures where only some of them might be time limited.
+#[derive(Debug)]
+pub enum OptionalTimeout<F: Future> {
+    Unlimited(F),
+    Limited(Timeout<F>),
+}
+
+impl<F: Future> OptionalTimeout<F> {
+    /// Creates a new `OptionalTimeout` future.
+    ///
+    /// The duration parameter may be `None` to indicate there is no time limit. This means that
+    /// `future` will run as normal.
+    pub fn new(future: F, timeout: Option<Duration>) -> Self {
+        match timeout {
+            Some(timeout) => OptionalTimeout::Limited(Timeout::new(future, timeout)),
+            None => OptionalTimeout::Unlimited(future),
+        }
+    }
+}
+
+impl<F: Future> Future for OptionalTimeout<F> {
+    type Item = F::Item;
+    type Error = Error<F::Error>;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self {
+            OptionalTimeout::Unlimited(future) => future.poll().map_err(Error::inner),
+            OptionalTimeout::Limited(future) => future.poll(),
+        }
+    }
+}

--- a/newhttp/tests/common/mod.rs
+++ b/newhttp/tests/common/mod.rs
@@ -1,0 +1,68 @@
+#![allow(dead_code)]
+
+use futures::Future;
+use jsonrpc_client_core::Transport;
+use jsonrpc_client_newhttp::{
+    hyper::{Client, Uri},
+    HttpTransport,
+};
+use jsonrpc_core::{Error, IoHandler};
+use jsonrpc_http_server::{self, ServerBuilder};
+use std::{thread, time::Duration};
+
+// Generate client struct with same API as server.
+jsonrpc_client_core::jsonrpc_client!(pub struct MockRpcClient {
+    pub fn to_upper(&mut self, s: &str, time: u64) -> Future<String>;
+});
+
+#[jsonrpc_derive::rpc]
+pub trait MockRpcServerApi {
+    #[rpc(name = "to_upper")]
+    fn to_upper(&self, s: String, time: u64) -> Result<String, Error>;
+}
+
+pub struct MockRpcServer;
+impl MockRpcServerApi for MockRpcServer {
+    fn to_upper(&self, s: String, time: u64) -> Result<String, Error> {
+        thread::sleep(Duration::from_millis(time));
+        Ok(s.to_uppercase())
+    }
+}
+
+impl MockRpcServer {
+    pub fn spawn() -> jsonrpc_http_server::Server {
+        let mut io = IoHandler::new();
+        io.extend_with(MockRpcServer.to_delegate());
+
+        ServerBuilder::new(io)
+            .start_http(&"127.0.0.1:0".parse().unwrap())
+            .expect("failed to spawn server")
+    }
+}
+
+/// Helper method that just creates a client and server talking to each other.
+pub fn spawn_client_server(
+    client_timeout: Option<Duration>,
+) -> (
+    tokio::runtime::Runtime,
+    MockRpcClient,
+    jsonrpc_http_server::Server,
+) {
+    let server = MockRpcServer::spawn();
+    let uri = format!("http://{}", server.address())
+        .parse::<Uri>()
+        .unwrap();
+
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    let client: Client<_, hyper::Body> = Client::new();
+
+    let jsonrpc_transport = HttpTransport::new(client, client_timeout);
+    let (jsonrpc_client_future, client_handle) = jsonrpc_transport.handle(uri).into_client();
+    let client = MockRpcClient::new(client_handle);
+
+    rt.spawn(jsonrpc_transport);
+    rt.spawn(jsonrpc_client_future.map_err(|e| log::error!("Error in JSON-RPC 2.0 client: {}", e)));
+
+    (rt, client, server)
+}

--- a/newhttp/tests/localhost.rs
+++ b/newhttp/tests/localhost.rs
@@ -1,0 +1,39 @@
+mod common;
+use common::spawn_client_server;
+
+use futures::{future::Either, Future};
+use std::time::{Duration, Instant};
+
+
+#[test]
+fn localhost_ping_pong() {
+    let (mut rt, mut client, _server) = spawn_client_server(None);
+
+    let rpc_future1 = client.to_upper("MaKe me UppeRcase!!1", 0);
+    let rpc_future2 = client.to_upper("foobar", 0);
+
+    let joined_future = rpc_future1.join(rpc_future2);
+    let (result1, result2) = rt.block_on(joined_future).unwrap();
+
+    assert_eq!("MAKE ME UPPERCASE!!1", result1);
+    assert_eq!("FOOBAR", result2);
+}
+
+#[test]
+fn dropped_rpc_request_should_not_crash_transport() {
+    let (mut rt, mut client, _server) = spawn_client_server(None);
+
+    let rpc = client.to_upper("", 1000).map_err(|e| e.to_string());
+    let timeout = tokio_timer::Delay::new(Instant::now() + Duration::from_millis(50));
+    match rt.block_on(rpc.select2(timeout)) {
+        Ok(Either::B(((), _rpc))) => (),
+        _ => panic!("The timeout did not finish first"),
+    }
+
+    // Now, sending a second request should still work. This is a regression test catching a
+    // previous error where a dropped `RpcRequest` would crash the future running on the event loop.
+    match rt.block_on(client.to_upper("foo", 0)) {
+        Ok(ref s) if s == "FOO" => (),
+        _ => panic!("Sleep did not return as it should"),
+    }
+}

--- a/newhttp/tests/timeout.rs
+++ b/newhttp/tests/timeout.rs
@@ -1,0 +1,23 @@
+mod common;
+use common::spawn_client_server;
+
+use std::time::Duration;
+
+#[test]
+fn slow_request_should_timeout() {
+    let (mut rt, mut client, _server) = spawn_client_server(Some(Duration::from_millis(50)));
+
+    let slow_rpc = client.to_upper("hard string takes too long to process ;)", 1000);
+    assert!(rt.block_on(slow_rpc).is_err());
+}
+
+#[test]
+fn fast_request_should_succeed() {
+    let (mut rt, mut client, _server) = spawn_client_server(Some(Duration::from_millis(5000)));
+
+    let fast_rpc = client.to_upper("foobar", 0);
+    match rt.block_on(fast_rpc) {
+        Ok(ref s) if s == "FOOBAR" => (),
+        _ => panic!("did not receive expected response"),
+    }
+}


### PR DESCRIPTION
This is trying to move away from the now old `tokio_core` and `hyper 0.11`.

I'm planning on replacing `jsonrpc_client_http` completely with this new hyper 0.12 based transport. But as a transition while it's being developed I opted to keep both until we know the new one is usable. So the name `newhttp` is not something that I ever mean to publish or anything.

This implementation does not support custom headers. But for our use case we should not need that any more. We previously needed it for host headers when we connected directly to IPs. But with the new DNS cache solution we should be able to connect directly to our domains and no special hacks for SNI or host header insertion should be needed.

This transport is also a lot simpler. It does not contain any "client creator" code. And no helpers for creating hyper clients. The user just have to hand us any `hyper::Client` and we'll work with that directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/jsonrpc-client-rs/56)
<!-- Reviewable:end -->
